### PR TITLE
False positive fix

### DIFF
--- a/Test-ADReplication.ps1
+++ b/Test-ADReplication.ps1
@@ -12,7 +12,7 @@ $DClist = (get-adgroupmember "Domain Controllers").name
 Foreach ($server in $DClist) {
     $Result = (Get-ADReplicationFailure -Target $server).failurecount
     
-        If ($result -ne $null -or $result -gt 0){
+        If ($result -ne $null -and $result -gt 0){
         
         $Subject = "Replication Failure on $Server"
         $EmailBody = @"


### PR DESCRIPTION
If the result is Zero the OR will still trigger because the value is not $null.
It should be an AND so the value is not $null and also greater than zero.