### PR TITLE
Added a Simple Slack Alert function

### DIFF
--- a/ADConfig.json
+++ b/ADConfig.json
@@ -7,6 +7,7 @@
     "ExternalTimeSvr":"<YOUR EXTERNAL-TIME-SERVER>",
     "MaxObjectReplCycles":"50",
     "MaxSysvolReplCycles":"50",
-    "SupportArticle":"https://<YourServer/YourTroubleshootingArticles>"
+    "SupportArticle":"https://<YourServer/YourTroubleshootingArticles>",
+    "SlackToken":"<YourSlackAPIToken>"
   }
   


### PR DESCRIPTION
In order for this to work with Slack you will need to:
- Have a Slack instance
- Configure API access in Slack
- Create the Slack channel PSMonitor
- The system running the monitor will need internet access (direct or proxy) to send to the Slack API
- The IE Enhanced Security Configuration on the system running the monitor script must be set to Off