### PR TITLE
Update Get-ADConfig. Fix references.

### DIFF
--- a/Public/Get-ADConfig.ps1
+++ b/Public/Get-ADConfig.ps1
@@ -26,6 +26,7 @@ function Get-ADConfig {
 
         $Global:Configuration = Get-Content $Configuration | ConvertFrom-JSON
 
+        $Configuration
     }
 
     end {}

--- a/Public/Get-ADLastBackupDate.ps1
+++ b/Public/Get-ADLastBackupDate.ps1
@@ -31,7 +31,7 @@ function Get-ADLastBackupDate {
 
     Begin {
         Import-Module activedirectory
-        Get-ADConfig
+        $null = Get-ADConfig
         $SupportArticle = $Configuration.SupportArticle
         if (![System.Diagnostics.EventLog]::SourceExists("PSMonitor")) {
             write-verbose "Adding Event Source."

--- a/Public/Test-ADObjectReplication.ps1
+++ b/Public/Test-ADObjectReplication.ps1
@@ -42,7 +42,7 @@ function Test-ADObjectReplication {
         $NBN = (Get-ADDomain).NetBIOSName
         $Domain = (Get-ADDomain).DNSRoot
         $domainname = (Get-ADDomain).dnsroot
-        Get-ADConfig
+        $null = Get-ADConfig
         $SupportArticle = $.SupportArticle
         if (![System.Diagnostics.EventLog]::SourceExists("PSMonitor")) {
             write-verbose "Adding Event Source."

--- a/Public/Test-ADReplication.ps1
+++ b/Public/Test-ADReplication.ps1
@@ -31,7 +31,7 @@ function Test-ADReplication {
 
     Begin {
         Import-Module activedirectory
-        Get-ADConfig
+        $null = Get-ADConfig
         $SupportArticle = $Configuration.SupportArticle
         if (![System.Diagnostics.EventLog]::SourceExists("PSMonitor")) {
             write-verbose "Adding Event Source."

--- a/Public/Test-ADServices.ps1
+++ b/Public/Test-ADServices.ps1
@@ -6,7 +6,7 @@ Function Test-ADServices {
     Begin {
 
         #Creates a global $configuration variable
-        Get-ADConfig
+        $null = Get-ADConfig
 
     }
 

--- a/Public/Test-ExternalTimeSync.ps1
+++ b/Public/Test-ExternalTimeSync.ps1
@@ -33,7 +33,7 @@ function Test-ADExternalTimeSync {
     Begin {
         Import-Module activedirectory
         $CurrentFailure = $null
-        Get-ADConfig
+        $null = Get-ADConfig
         $SupportArticle = $Configuration.SupportArticle
         $SlackToken = $Configuration.SlackToken
         if (![System.Diagnostics.EventLog]::SourceExists("PSMonitor")) {

--- a/Public/Test-InternalTimeSync.ps1
+++ b/Public/Test-InternalTimeSync.ps1
@@ -33,7 +33,7 @@ function Test-ADInternalTimeSync {
     Begin {
         Import-Module activedirectory
         $CurrentFailure = $null
-        Get-ADConfig
+        $null = Get-ADConfig
         $SupportArticle = $Configuration.SupportArticle
         $SlackToken = $Configuration.SlackToken
         if (![System.Diagnostics.EventLog]::SourceExists("PSMonitor")) {

--- a/Public/Test-SYSVOL-Replication.ps1
+++ b/Public/Test-SYSVOL-Replication.ps1
@@ -45,7 +45,7 @@ function Test-SysvolReplication {
 
     Begin {
         Import-Module activedirectory
-        Get-ADConfig
+        $null = Get-ADConfig
         $SupportArticle = $Configuration.SupportArticle
         if (![System.Diagnostics.EventLog]::SourceExists("PSMonitor")) {
             write-verbose "Adding Event Source."


### PR DESCRIPTION
Outputs object when calling `Get-ADConfig`. Fix references so that is nulled in other functions.

Fixes #49 